### PR TITLE
[BUGFIX] Rename internal data structure to internalDTOData

### DIFF
--- a/src/DTOAccessorTrait.php
+++ b/src/DTOAccessorTrait.php
@@ -9,7 +9,7 @@
 namespace CodinPro\DataTransferObject;
 
 /**
- * @property mixed $data DTO data
+ * @property mixed $innerDTOData DTO data
  * @property array $default DTO keys and default values
  */
 trait DTOAccessorTrait

--- a/src/DTOAccessorTrait.php
+++ b/src/DTOAccessorTrait.php
@@ -10,7 +10,7 @@ namespace CodinPro\DataTransferObject;
 
 /**
  * @property mixed $innerDTOData DTO data
- * @property array $default DTO keys and default values
+ * @property array $innerDTODefault DTO keys and default values
  */
 trait DTOAccessorTrait
 {
@@ -54,8 +54,8 @@ trait DTOAccessorTrait
      */
     private function getDefaultValue($offset)
     {
-        if (array_key_exists($offset, $this->default)) {
-            return $this->default[$offset];
+        if (array_key_exists($offset, $this->innerDTODefault)) {
+            return $this->innerDTODefault[$offset];
         }
 
         throw new \InvalidArgumentException('Offset '.$offset.' does not exist.');

--- a/src/DTOAccessorTrait.php
+++ b/src/DTOAccessorTrait.php
@@ -28,7 +28,7 @@ trait DTOAccessorTrait
      */
     public function offsetExists($offset)
     {
-        return isset($this->data[$offset]);
+        return isset($this->innerDTOData[$offset]);
     }
 
     /**
@@ -39,8 +39,8 @@ trait DTOAccessorTrait
      */
     private function offsetGetScalar($offset)
     {
-        if (array_key_exists($offset, $this->data)) {
-            return $this->data[$offset];
+        if (array_key_exists($offset, $this->innerDTOData)) {
+            return $this->innerDTOData[$offset];
         }
 
         return $this->getDefaultValue($offset);
@@ -79,7 +79,7 @@ trait DTOAccessorTrait
      */
     public function offsetSet($offset, $value)
     {
-        $this->data[$offset] = $value;
+        $this->innerDTOData[$offset] = $value;
     }
 
     /**
@@ -88,7 +88,7 @@ trait DTOAccessorTrait
      */
     public function offsetUnset($offset)
     {
-        unset($this->data[$offset]);
+        unset($this->innerDTOData[$offset]);
     }
 
     /**
@@ -97,7 +97,7 @@ trait DTOAccessorTrait
      */
     public function count()
     {
-        return count($this->data);
+        return count($this->innerDTOData);
     }
 
     public function __get($key)
@@ -112,6 +112,6 @@ trait DTOAccessorTrait
 
     public function __isset($key)
     {
-        return isset($this->data[$key]);
+        return isset($this->innerDTOData[$key]);
     }
 }

--- a/src/DTOBase.php
+++ b/src/DTOBase.php
@@ -8,7 +8,7 @@ use IteratorAggregate;
 
 class DTOBase implements ArrayAccess, IteratorAggregate, Countable
 {
-    protected $data;
+    protected $innerDTOData;
     protected $default = [];
     private $serializer = null;
 
@@ -66,7 +66,7 @@ class DTOBase implements ArrayAccess, IteratorAggregate, Countable
         if ($this->serializer instanceof JsonSerializer) {
             return json_decode($this->serialize(), true);
         } else {
-            return json_decode((new JsonSerializer())->serialize($this->data), true);
+            return json_decode((new JsonSerializer())->serialize($this->innerDTOData), true);
         }
     }
 
@@ -76,7 +76,7 @@ class DTOBase implements ArrayAccess, IteratorAggregate, Countable
      */
     private function serialize()
     {
-        return $this->serializer->serialize($this->data);
+        return $this->serializer->serialize($this->innerDTOData);
     }
 
     /**
@@ -115,7 +115,7 @@ class DTOBase implements ArrayAccess, IteratorAggregate, Countable
     private function processChain($offset)
     {
         $keys = explode('.', $offset);
-        $scope = $this->data;
+        $scope = $this->innerDTOData;
         foreach ($keys as $key) {
             $scope = $this->pickValue($scope, $key);
         }

--- a/src/DTOBase.php
+++ b/src/DTOBase.php
@@ -9,7 +9,7 @@ use IteratorAggregate;
 class DTOBase implements ArrayAccess, IteratorAggregate, Countable
 {
     protected $innerDTOData;
-    protected $default = [];
+    protected $innerDTODefault = [];
     private $serializer = null;
 
     use DTOAccessorTrait;
@@ -25,7 +25,7 @@ class DTOBase implements ArrayAccess, IteratorAggregate, Countable
     public function __construct($default = [], $data = [], DTOSerializerInterface $serializer = null)
     {
         if (count($default) > 0) {
-            $this->default = $default;
+            $this->innerDTODefault = $default;
         }
 
         $this->serializer = $serializer === null ? new JsonSerializer() : $serializer;
@@ -103,7 +103,7 @@ class DTOBase implements ArrayAccess, IteratorAggregate, Countable
      */
     public function getDefault()
     {
-        return $this->default;
+        return $this->innerDTODefault;
     }
 
     /**

--- a/src/DTOIteratorTrait.php
+++ b/src/DTOIteratorTrait.php
@@ -10,7 +10,7 @@ namespace CodinPro\DataTransferObject;
 
 /**
  * @property mixed $innerDTOData DTO data
- * @property array $default DTO keys and default values
+ * @property array $innerDTODefault DTO keys and default values
  */
 trait DTOIteratorTrait
 {

--- a/src/DTOIteratorTrait.php
+++ b/src/DTOIteratorTrait.php
@@ -9,7 +9,7 @@
 namespace CodinPro\DataTransferObject;
 
 /**
- * @property mixed $data DTO data
+ * @property mixed $innerDTOData DTO data
  * @property array $default DTO keys and default values
  */
 trait DTOIteratorTrait
@@ -20,6 +20,6 @@ trait DTOIteratorTrait
      */
     public function getIterator()
     {
-        return new DTOIterator($this->data);
+        return new DTOIterator($this->innerDTOData);
     }
 }


### PR DESCRIPTION
Rename internal `data` and `default` fields to `internalDTO*`. Previous naming caused conflicts when init data had fields with such names.